### PR TITLE
Upgrade to fp-ts 2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -57,9 +57,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "8.0.19",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.19.tgz",
-      "integrity": "sha512-VRQB+Q0L3YZWs45uRdpN9oWr82meL/8TrJ6faoKT5tp0uub2l/aRMhtm5fo68h7kjYKH60f9/bay1nF7ZpTW5g==",
+      "version": "12.7.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.8.tgz",
+      "integrity": "sha512-FMdVn84tJJdV+xe+53sYiZS4R5yn1mAIxfj+DVoNiQjTYz1+OYmjwEZr1ev9nU0axXwda0QDbYl06QHanRVH3A==",
       "dev": true
     },
     "abab": {
@@ -1565,6 +1565,12 @@
             "esutils": "^2.0.2"
           }
         },
+        "fp-ts": {
+          "version": "1.19.5",
+          "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-1.19.5.tgz",
+          "integrity": "sha512-wDNqTimnzs8QqpldiId9OavWK2NptormjXnRJTQecNjzwfyp6P/8s/zG8e4h3ja3oqkKaY72UlTjQYt/1yXf9A==",
+          "dev": true
+        },
         "fs-extra": {
           "version": "7.0.1",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
@@ -2321,9 +2327,9 @@
       }
     },
     "fp-ts": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-1.19.2.tgz",
-      "integrity": "sha512-d0XFXQDffTtwyfO7uhYz7xWhZcdRxHCbvxPhWrk8uPDKyE04lQooBWCggtqNYNnlkj46K8c5jGDrYc2UKN/1nA==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.0.5.tgz",
+      "integrity": "sha512-opI5r+rVlpZE7Rhk0YtqsrmxGkbIw0dRNqGca8FEAMMnjomXotG+R9QkLQg20onx7R8qhepAn4CCOP8usma/Xw==",
       "dev": true
     },
     "fragment-cache": {
@@ -6868,9 +6874,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.2.tgz",
-      "integrity": "sha512-7KxJovlYhTX5RaRbUdkAXN1KUZ8PwWlTzQdHV6xNqvuFOs7+WBo10TQUqT19Q/Jz2hk5v9TQDIhyLhhJY4p5AA==",
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.3.tgz",
+      "integrity": "sha512-N7bceJL1CtRQ2RiG0AQME13ksR7DiuQh/QehubYcghzv20tnh+MQnQIuJddTmsbqYj+dztchykemz0zFzlvdQw==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -29,20 +29,20 @@
   },
   "homepage": "https://github.com/gcanti/logging-ts",
   "peerDependencies": {
-    "fp-ts": "^1.7.0"
+    "fp-ts": "^2.0.5"
   },
   "devDependencies": {
     "@types/jest": "^22.2.2",
-    "@types/node": "8.0.19",
+    "@types/node": "^12.7.8",
     "docs-ts": "0.0.3",
-    "fp-ts": "^1.19.2",
+    "fp-ts": "^2.0.5",
     "jest": "^22.4.3",
     "prettier": "^1.18.2",
     "ts-jest": "^22.4.2",
     "ts-node": "3.3.0",
     "tslint": "5.9.1",
     "tslint-config-standard": "7.0.0",
-    "typescript": "^3.5.2"
+    "typescript": "^3.6.3"
   },
   "tags": [
     "typescript",

--- a/src/Console.ts
+++ b/src/Console.ts
@@ -1,6 +1,6 @@
-import { Logger } from './'
+import { getLogger, Logger } from './'
 import { URI } from 'fp-ts/lib/IO'
 import { log } from 'fp-ts/lib/Console'
 
 /** Returns a `Logger` that logs records to the console */
-export const console = <A>(f: (a: A) => string): Logger<URI, A> => new Logger(a => log(f(a)))
+export const console = <A>(f: (a: A) => string): Logger<URI, A> => getLogger(a => log(f(a)))

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,16 +1,17 @@
-import { Applicative, Applicative1, Applicative2, Applicative3, when } from 'fp-ts/lib/Applicative'
-import { Apply, Apply1, Apply2, Apply3, applySecond } from 'fp-ts/lib/Apply'
+import { Applicative, Applicative1, Applicative2, Applicative3 } from 'fp-ts/lib/Applicative'
+import { Apply, Apply1, Apply2, Apply3, sequenceT } from 'fp-ts/lib/Apply'
 import { Contravariant2 } from 'fp-ts/lib/Contravariant'
-import { HKT, Type, Type2, Type3, URIS, URIS2, URIS3 } from 'fp-ts/lib/HKT'
+import { HKT, Kind, Kind2, Kind3, URIS, URIS2, URIS3 } from 'fp-ts/lib/HKT'
 import { Monoid } from 'fp-ts/lib/Monoid'
 import { Semigroup } from 'fp-ts/lib/Semigroup'
 import { Predicate } from 'fp-ts/lib/function'
 
+import { option, fromPredicate } from 'fp-ts/lib/Option'
 // Adapted from https://github.com/rightfold/purescript-logging
 
 declare module 'fp-ts/lib/HKT' {
-  interface URI2HKT2<L, A> {
-    Logger: Logger<L, A>
+  interface URItoKind2<E, A> {
+    Logger: Logger<E, A>
   }
 }
 
@@ -19,14 +20,8 @@ export const URI = 'Logger'
 export type URI = typeof URI
 
 /** A logger receives records and potentially performs some effects */
-export class Logger<M, A> {
-  readonly _A!: A
-  readonly _L!: M
-  readonly _URI!: URI
-  constructor(readonly run: (a: A) => HKT<M, void>) {}
-  contramap<B>(f: (b: B) => A): Logger<M, B> {
-    return new Logger(b => this.run(f(b)))
-  }
+export interface Logger<M, A> {
+  (a: A): HKT<M, void>
 }
 
 export function getSemigroup<M extends URIS3>(M: Apply3<M>): <A = never>() => Semigroup<Logger<M, A>>
@@ -34,9 +29,9 @@ export function getSemigroup<M extends URIS2>(M: Apply2<M>): <A = never>() => Se
 export function getSemigroup<M extends URIS>(M: Apply1<M>): <A = never>() => Semigroup<Logger<M, A>>
 export function getSemigroup<M>(M: Apply<M>): <A = never>() => Semigroup<Logger<M, A>>
 export function getSemigroup<M>(M: Apply<M>): <A = never>() => Semigroup<Logger<M, A>> {
-  const applySecondM = applySecond(M)
+  const applySequenceM = sequenceT(M)
   return () => ({
-    concat: (x, y) => new Logger(a => applySecondM(x.run(a), y.run(a)))
+    concat: (x, y) => a => M.map(applySequenceM(x(a), y(a)), () => undefined)
   })
 }
 
@@ -46,7 +41,7 @@ export function getMonoid<M extends URIS>(M: Applicative1<M>): <A = never>() => 
 export function getMonoid<M>(M: Applicative<M>): <A = never>() => Monoid<Logger<M, A>>
 export function getMonoid<M>(M: Applicative<M>): <A = never>() => Monoid<Logger<M, A>> {
   const S = getSemigroup(M)<any>()
-  const empty = new Logger<M, any>(() => M.of(undefined))
+  const empty = () => M.of(undefined)
   return () => ({
     ...S,
     empty
@@ -65,37 +60,39 @@ export function filter<M extends URIS>(
 ): <A>(logger: Logger<M, A>, predicate: Predicate<A>) => Logger<M, A>
 export function filter<M>(M: Applicative<M>): <A>(logger: Logger<M, A>, predicate: Predicate<A>) => Logger<M, A>
 export function filter<M>(M: Applicative<M>): <A>(logger: Logger<M, A>, predicate: Predicate<A>) => Logger<M, A> {
-  const whenM = when(M)
-  return (logger, predicate) => new Logger(a => whenM(predicate(a), logger.run(a)))
+  const whenM = option.wither(M)
+  return (logger, predicate) => a => M.map(whenM(fromPredicate(predicate)(a), (a) => M.map(logger(a), option.of)), () => undefined)
 }
 
 /** Apply a natural transformation to the underlying functor */
 export function hoist<F extends URIS3, G extends URIS3>(
-  nt: <U, L, A>(fa: Type3<F, U, L, A>) => Type3<G, U, L, A>
+  nt: <U, L, A>(fa: Kind3<F, U, L, A>) => Kind3<G, U, L, A>
 ): <A>(logger: Logger<F, A>) => Logger<G, A>
 export function hoist<F extends URIS2, G extends URIS2>(
-  nt: <L, A>(fa: Type2<F, L, A>) => Type2<G, L, A>
+  nt: <L, A>(fa: Kind2<F, L, A>) => Kind2<G, L, A>
 ): <A>(logger: Logger<F, A>) => Logger<G, A>
 export function hoist<F extends URIS, G extends URIS>(
-  nt: <A>(fa: Type<F, A>) => Type<G, A>
+  nt: <A>(fa: Kind<F, A>) => Kind<G, A>
 ): <A>(logger: Logger<F, A>) => Logger<G, A>
 export function hoist<F, G>(nt: <A>(fa: HKT<F, A>) => HKT<G, A>): <A>(logger: Logger<F, A>) => Logger<G, A>
 export function hoist<F, G>(nt: <A>(fa: HKT<F, A>) => HKT<G, A>): <A>(logger: Logger<F, A>) => Logger<G, A> {
-  return logger => new Logger(a => nt(logger.run(a)))
+  return logger => a => nt(logger(a))
 }
 
 /** Log a record to the logger */
-export function log<M extends URIS3, A>(logger: Logger<M, A>): <U, L>(a: A) => Type3<M, U, L, void>
-export function log<M extends URIS2, A>(logger: Logger<M, A>): <L>(a: A) => Type2<M, L, void>
-export function log<M extends URIS, A>(logger: Logger<M, A>): (a: A) => Type<M, void>
+export function log<M extends URIS3, A>(logger: Logger<M, A>): <U, L>(a: A) => Kind3<M, U, L, void>
+export function log<M extends URIS2, A>(logger: Logger<M, A>): <L>(a: A) => Kind2<M, L, void>
+export function log<M extends URIS, A>(logger: Logger<M, A>): (a: A) => Kind<M, void>
 export function log<M, A>(logger: Logger<M, A>): (a: A) => HKT<M, void>
 export function log<M, A>(logger: Logger<M, A>): (a: A) => HKT<M, void> {
-  return a => logger.run(a)
+  return a => logger(a)
 }
 
 const contramap = <M, A, B>(fa: Logger<M, A>, f: (b: B) => A): Logger<M, B> => {
-  return fa.contramap(f)
+  return (b) => fa(f(b))
 }
+
+export const getLogger = <M extends URIS, A>(l: (a: A) => Kind<M, void>) => l as (a: A) => Kind<M, void> & { _URI: M, _A: void }
 
 export const logger: Contravariant2<URI> = {
   URI,

--- a/test/index.ts
+++ b/test/index.ts
@@ -1,76 +1,53 @@
 import * as assert from 'assert'
-import { Logger, filter, getSemigroup, getMonoid, log, hoist, logger } from '../src/'
-import { IO, URI as IOURI, io } from 'fp-ts/lib/IO'
+import { getLogger, Logger, filter, getSemigroup, getMonoid, log, hoist, logger } from '../src/'
+import { URI as IOURI, io, chain } from 'fp-ts/lib/IO'
 import { URI as TaskURI, fromIO } from 'fp-ts/lib/Task'
+
+import { pipe } from 'fp-ts/lib/pipeable'
 
 describe('Logger', () => {
   it('contramap', () => {
     const ledger: Array<number> = []
-    const ledgerLogger = new Logger<IOURI, number>(
-      a =>
-        new IO(() => {
-          ledger.push(a)
-        })
-    )
+    const ledgerLogger: Logger<IOURI, number> = getLogger(a => () => { ledger.push(a) })
     const testLogger = logger.contramap(ledgerLogger, (s: string) => s.length)
-    log(testLogger)('a').run()
+    log(testLogger)('a')()
     assert.deepEqual(ledger, [1])
   })
 
   it('getSemigroup', () => {
     const ledger: Array<string> = []
     const S = getSemigroup(io)<string>()
-    const ledgerLogger = new Logger<IOURI, string>(
-      a =>
-        new IO(() => {
-          ledger.push(a)
-        })
-    )
+    const ledgerLogger: Logger<IOURI, string> = getLogger(a => () => { ledger.push(a) })
     const testLogger = S.concat(ledgerLogger, ledgerLogger)
-    log(testLogger)('a').run()
+    log(testLogger)('a')()
     assert.deepEqual(ledger, ['a', 'a'])
   })
 
   it('getMonoid', () => {
     const ledger: Array<string> = []
     const M = getMonoid(io)<string>()
-    const ledgerLogger = new Logger<IOURI, string>(
-      a =>
-        new IO(() => {
-          ledger.push(a)
-        })
-    )
+    const ledgerLogger: Logger<IOURI, string> = getLogger(a => () => { ledger.push(a) })
     const testLogger = M.concat(ledgerLogger, M.empty)
-    log(testLogger)('a').run()
+    log(testLogger)('a')()
     assert.deepEqual(ledger, ['a'])
   })
 
   it('filter', () => {
     const ledger: Array<string> = []
-    const ledgerLogger = new Logger<IOURI, string>(
-      a =>
-        new IO(() => {
-          ledger.push(a)
-        })
-    )
+    const ledgerLogger: Logger<IOURI, string> = getLogger(a => () => { ledger.push(a) })
     const testLogger = filter(io)(ledgerLogger, a => a.length > 2)
     const testLog = log(testLogger)
-    testLog('a').run()
-    testLog('aaa').run()
+    testLog('a')()
+    testLog('aaa')()
     assert.deepEqual(ledger, ['aaa'])
   })
 
   it('hoist', () => {
     const ledger: Array<string> = []
-    const ledgerLogger = new Logger<IOURI, string>(
-      a =>
-        new IO(() => {
-          ledger.push(a)
-        })
-    )
+    const ledgerLogger: Logger<IOURI, string> = getLogger(a => () => { ledger.push(a) })
     const testLogger = hoist<IOURI, TaskURI>(fromIO)(ledgerLogger)
     const testLog = log(testLogger)
-    return Promise.all([testLog('a').run()]).then(() => {
+    return Promise.all([testLog('a')()]).then(() => {
       assert.deepEqual(ledger, ['a'])
     })
   })
@@ -88,12 +65,9 @@ describe('Logger', () => {
     const format = (date: Date): string => `${date.getFullYear()}-${date.getMonth() + 1}-${date.getDate()}`
 
     const fileLogger = (path: string): Logger<IOURI, Entry> =>
-      new Logger(
-        ({ level, time, message }) =>
-          new IO(() => {
-            mock.push(`${path}: [${level}] ${format(time)} ${message}`)
-          })
-      )
+        getLogger(({ level, time, message }) =>
+          () => { mock.push(`${path}: [${level}] ${format(time)} ${message}`) }
+        )
 
     const filterIO = filter(io)
     const debugLogger = filterIO(fileLogger('debug.log'), e => e.level === 'Debug')
@@ -105,14 +79,16 @@ describe('Logger', () => {
     const info = (message: string) => (time: Date) => logIO({ message, time, level: 'Info' })
     const debug = (message: string) => (time: Date) => logIO({ message, time, level: 'Debug' })
 
-    const now = new IO(() => new Date(1970, 10, 30))
+    const now = () => new Date(1970, 10, 30)
 
-    const program = now
-      .chain(info('boot'))
-      .chain(() => now)
-      .chain(debug('Hello!'))
+    const program = pipe(
+      now,
+      chain(info('boot')),
+      chain(() => now),
+      chain(debug('Hello!'))
+    )
 
-    program.run()
+    program()
     assert.deepEqual(mock, ['production.log: [Info] 1970-11-30 boot', 'debug.log: [Debug] 1970-11-30 Hello!'])
   })
 })


### PR DESCRIPTION
It upgrades `fp-ts` to 2.0. Related to #8. 

I defined a logger with an interface

```
interface Logger<M, A> {
  (a: A): HKT<M, void>
}
```
The problem is that `HKT<M, void>` is a "phantom" type and any `Logger` implementation returns a `Kind<M, void>` instead, resulting in a type error.

My solution is a logger "constructor" that "attaches" (virtually) `_URI` and and `_A` to a simple `Kind<M, void>` object.

```
const getLogger = <M extends URIS, A>(l: (a: A) => Kind<M, void>) => l as (a: A) => Kind<M, void> & { _URI: M, _A: void }
```
It is the first time I play with `fp-ts` HKTs, so I do not know if there is a better way. What do you think, @gcanti?

TODO
- [ ] bump version
- [ ] update `README`