### PR TITLE
Add async logger

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "logging-ts",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -5851,7 +5851,8 @@
             "ansi-regex": {
               "version": "2.1.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -5872,12 +5873,14 @@
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -5892,17 +5895,20 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -6019,7 +6025,8 @@
             "inherits": {
               "version": "2.0.3",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -6031,6 +6038,7 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -6045,6 +6053,7 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -6052,12 +6061,14 @@
             "minimist": {
               "version": "0.0.8",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -6076,6 +6087,7 @@
               "version": "0.5.1",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -6156,7 +6168,8 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -6168,6 +6181,7 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -6253,7 +6267,8 @@
             "safe-buffer": {
               "version": "5.1.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -6289,6 +6304,7 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -6308,6 +6324,7 @@
               "version": "3.0.1",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -6351,12 +6368,14 @@
             "wrappy": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.0.3",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -1,0 +1,36 @@
+import { Contravariant1 } from 'fp-ts/lib/Contravariant'
+import { Predicate } from 'fp-ts/lib/function'
+import { Task, task } from 'fp-ts/lib/Task'
+import { Monoid } from 'fp-ts/lib/Monoid'
+import { pipeable } from 'fp-ts/lib/pipeable'
+
+import { getLoggerM } from '.'
+
+const T = getLoggerM(task)
+
+declare module 'fp-ts/lib/HKT' {
+  interface URItoKind<A> {
+    LoggerTask: LoggerTask<A>
+  }
+}
+
+export const URI = 'LoggerTask'
+
+export type URI = typeof URI
+
+export interface LoggerTask<A> {
+  (a: A): Task<void>
+}
+
+export const filter: <A>(logger: LoggerTask<A>, predicate: Predicate<A>) => LoggerTask<A> = T.filter
+
+export const getMonoid: <A = never>() => Monoid<LoggerTask<A>> = T.getMonoid
+
+export const loggerTask: Contravariant1<URI> = {
+  URI,
+  contramap: T.contramap
+}
+
+const { contramap } = pipeable(loggerTask)
+
+export { contramap }

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -1,3 +1,7 @@
+/**
+ * @since 0.3.1
+ */
+
 import { Contravariant1 } from 'fp-ts/lib/Contravariant'
 import { Predicate } from 'fp-ts/lib/function'
 import { Task, task } from 'fp-ts/lib/Task'
@@ -14,18 +18,36 @@ declare module 'fp-ts/lib/HKT' {
   }
 }
 
+/**
+ * @since 0.3.1
+ */
 export const URI = 'LoggerTask'
 
+/**
+ * @since 0.3.1
+ */
 export type URI = typeof URI
 
+/**
+ * @since 0.3.1
+ */
 export interface LoggerTask<A> {
   (a: A): Task<void>
 }
 
+/**
+ * @since 0.3.1
+ */
 export const filter: <A>(logger: LoggerTask<A>, predicate: Predicate<A>) => LoggerTask<A> = T.filter
 
+/**
+ * @since 0.3.1
+ */
 export const getMonoid: <A = never>() => Monoid<LoggerTask<A>> = T.getMonoid
 
+/**
+ * @since 0.3.1
+ */
 export const loggerTask: Contravariant1<URI> = {
   URI,
   contramap: T.contramap

--- a/test/task.ts
+++ b/test/task.ts
@@ -1,0 +1,50 @@
+import * as assert from 'assert'
+
+import * as T from 'fp-ts/lib/Task'
+
+import * as C from 'fp-ts/lib/Console'
+import * as L from '../src/Task'
+
+describe('TaskLogger', () => {
+  let ledger: Array<number>
+  let consolelog: any
+
+  const asyncLog = (s: unknown) => T.fromIO(C.log(s))
+
+  beforeEach(() => {
+    ledger = []
+    consolelog = console.log
+    console.log = (message: any) => ledger.push(message)
+  })
+
+  afterEach(() => {
+    console.log = consolelog
+  })
+
+  it('contramap', () => {
+    const logger = L.loggerTask.contramap(asyncLog, (s: string) => s.length)
+    logger('a')()
+    assert.deepEqual(ledger, [1])
+  })
+
+  it('getSemigroup', () => {
+    const S = L.getMonoid<string>()
+    const logger = S.concat(asyncLog, asyncLog)
+    logger('a')()
+    assert.deepEqual(ledger, ['a', 'a'])
+  })
+
+  it('getMonoid', () => {
+    const M = L.getMonoid<string>()
+    const logger = M.concat(asyncLog, M.empty)
+    logger('a')()
+    assert.deepEqual(ledger, ['a'])
+  })
+
+  it('filter', () => {
+    const logger = L.filter(asyncLog, (a: string) => a.length > 2)
+    logger('a')()
+    logger('aaa')()
+    assert.deepEqual(ledger, ['aaa'])
+  })
+})


### PR DESCRIPTION
I added a simple `LoggerTask` based on `LoggerIO` implementation. Why?

* External logging services are asynchronous
* In [some](https://levelup.gitconnected.com/avoiding-the-pitfalls-of-async-node-js-functions-in-aws-lambda-941220582e7a) contexts, we cannot just "throw away" a promise: we need to "wait" explicitly.

Thanks!